### PR TITLE
Support summary with subcommand.

### DIFF
--- a/docs/remctld.pod
+++ b/docs/remctld.pod
@@ -297,17 +297,14 @@ summary to standard output.
 If remctld receives the command C<help> with no arguments, and no C<help>
 command is defined in the configuration file, the server will look through
 the configuration for any command with a C<summary> option set.  If this
-option is set, the I<subcommand> is C<ALL>, and the user is authorized to
-run the command, the server will run the specified I<executable> with the
-argument I<arg>, sending the output back to the user.  It will do this for
-every command in the configuration that meets the above criteria.
+option is set, and the user is authorized to run the command, the server
+will run the specified I<executable> with the argument I<arg>, sending the 
+output back to the user.  It will do this for every command in the 
+configuration that meets the above criteria.
 
 This allows display of a summary of available commands to the user based
 on which commands that user is authorized to run.  It's a lightweight form
 of service discovery.  Also see the C<help> option.
-
-As mentioned above, this option is only meaningful on configuration lines
-with a I<subcommand> of C<ALL>.
 
 =item user=(I<username> | I<uid>)
 

--- a/server/commands.c
+++ b/server/commands.c
@@ -115,8 +115,6 @@ server_send_summary(struct client *client, struct config *config)
         memset(&process, 0, sizeof(process));
         process.client = client;
         rule = config->rules[i];
-        if (strcmp(rule->subcommand, "ALL") != 0)
-            continue;
         if (!server_config_acl_permit(rule, client->user))
             continue;
         if (rule->summary == NULL)
@@ -129,15 +127,32 @@ server_send_summary(struct client *client, struct config *config)
          * argv and pass off to be executed.
          */
         path = rule->program;
-        req_argv = xcalloc(3, sizeof(char *));
+        req_argv = xcalloc(4, sizeof(char *));
         program = strrchr(path, '/');
         if (program == NULL)
             program = path;
         else
             program++;
+	
         req_argv[0] = program;
         req_argv[1] = rule->summary;
-        req_argv[2] = NULL;
+
+        if ( (strcmp(rule->subcommand, "ALL") == 0) 
+            || (strcmp(rule->subcommand, "EMPTY") == 0) )
+        {
+            req_argv[2] = NULL;
+        }
+        else {
+            /*
+             * Github issue #3:
+             * If a subcommand is specified, use it
+             * to create a subcommand specialized summary.
+             */
+            req_argv[2] = rule->subcommand;
+        }
+        
+        req_argv[3] = NULL;
+
         process.command = rule->summary;
         process.argv = req_argv;
         process.rule = rule;

--- a/tests/data/cmd-help
+++ b/tests/data/cmd-help
@@ -5,9 +5,13 @@ help)
     subhelp)    echo "subhelp text" ;;
     *)          echo "help text" ;;
     esac ;;
-summary)    echo "summary text" ;;
+summary) 
+    case "$2" in
+    subcommand) echo "subcommand summary" ;;
+    *)          echo "summary text" ;;
+    esac ;;
 *)
-    echo "requested $1 for help"
+    echo "requested '$1' for help"
     exit 1
     ;;
 esac

--- a/tests/data/conf-simple.in
+++ b/tests/data/conf-simple.in
@@ -15,6 +15,9 @@ test sigpipe @abs_top_builddir@/tests/data/cmd-sigpipe ANYUSER
 test-summary ALL @abs_top_srcdir@/tests/data/cmd-help \
     summary=summary \
     help=help ANYUSER
+test-summary-with-subcommand subcommand @abs_top_srcdir@/tests/data/cmd-help \
+    summary=summary \
+    help=help ANYUSER
 empty EMPTY @abs_top_srcdir@/tests/data/cmd-argv ANYUSER
 all ALL @abs_top_srcdir@/tests/data/cmd-hello ANYUSER
 ALL bar @abs_top_srcdir@/tests/data/cmd-hello ANYUSER

--- a/tests/server/summary-t.c
+++ b/tests/server/summary-t.c
@@ -40,12 +40,13 @@ main(void)
         bail("remctl returned NULL");
     is_int(0, result->status, "...with correct status");
     is_int(0, result->stderr_len, "...and no stderr");
-    is_int(13, result->stdout_len, "...and correct stdout_len");
+    is_int(32, result->stdout_len, "...and correct stdout_len");
     if (result->stdout_buf == NULL)
         ok(0, "...and correct data");
-    else
-        ok(memcmp("summary text\n", result->stdout_buf, 13) == 0,
+    else {
+        ok(memcmp("summary text\nsubcommand summary\n", result->stdout_buf, 32) == 0,
            "...and correct data");
+    }
     is_string(NULL, result->error, "...and no error");
     remctl_result_free(result);
     process_stop(remctld);


### PR DESCRIPTION
This pull request is a proposal for solving rra/remctl#3.

* If a summary option is specified with a subcommand other than `ALL`, create a subcommand specific summary.
* Adapt existing test suite.
* Adapt existing summary option documentation.