### PR TITLE
Retry getgrnam_r with larger buffer on ERANGE

### DIFF
--- a/server/config.c
+++ b/server/config.c
@@ -979,7 +979,7 @@ fail:
 static enum config_status
 acl_getgrnam(const char *group, struct group **grp, char **buffer)
 {
-    size_t buflen;
+    size_t buflen, buf_incr;
     int status, oerrno;
     struct group *result;
     enum config_status retval;
@@ -988,22 +988,27 @@ acl_getgrnam(const char *group, struct group **grp, char **buffer)
     *grp = NULL;
     *buffer = NULL;
 
-    /* Determine the size of the buffer for getgrnam_r. */
+    /* Determine the initial size of the buffer for getgrnam_r. */
     buflen = sysconf(_SC_GETGR_R_SIZE_MAX);
     if (buflen <= 0)
         buflen = BUFSIZ;
+    buf_incr = buflen;
     *buffer = xmalloc(buflen);
 
-    /* Get the group information, repeating on EINTR. */
+    /* Get the group information, retrying on EINTR or ERANGE. */
     *grp = xmalloc(sizeof(struct group));
     do {
         status = getgrnam_r(group, *grp, *buffer, buflen, &result);
-        if (status != 0 && status != EINTR) {
+        /* On ERANGE, expand the buffer size and retry */
+        if (status == ERANGE) {
+            buflen += buf_incr;
+            *buffer = xrealloc(*buffer, buflen);
+        } else if (status != 0 && status != EINTR) {
             errno = status;
             retval = CONFIG_ERROR;
             goto fail;
         }
-    } while (status == EINTR);
+    } while (status == EINTR || status == ERANGE);
 
     /* If not found, free all the memory and return success with NULL. */
     if (result == NULL) {


### PR DESCRIPTION
We ran into a problem when using a group with 63 members in a localgroup: ACL, where access would always be denied even if users were in the group. There was an accompanying message in the log from remctld:

    retrieving membership of localgroup xyz failed: Numerical result out of range

After researching the problem I found https://bugs.ruby-lang.org/issues/9600 and http://tomlee.co/2012/10/problems-with-large-linux-unix-groups-and-getgrgid_r-getgrnam_r/ which indicate that `sysconf(_SC_GETGR_R_SIZE_MAX)` may not return a large enough buffer size to hold a group's members, and if the call to `getgrnam_r` fails with ERANGE, the caller should retry with a larger buffer. I've written this patch to retry with a larger buffer in that case.