### PR TITLE
Fix maven plugin warnings and javadoc errors

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -33,6 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -58,6 +59,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
@@ -70,6 +72,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
                 <configuration>
                     <junitArtifactName>junit:junit</junitArtifactName>
 

--- a/java/src/main/java/org/eyrie/remctl/client/RemctlClientCli.java
+++ b/java/src/main/java/org/eyrie/remctl/client/RemctlClientCli.java
@@ -14,13 +14,13 @@ import org.slf4j.LoggerFactory;
  * Allows invoking the Java remctl client from the command line.
  * <p>
  * During development this can be run with
+ * </p>
  * 
  * <pre>
  * mvn exec:java -Djava.security.auth.login.config=gss_jaas.conf \
  *  -Dexec.mainClass=org.eyrie.remctl.client.RemctlClientCli -Dexec.args="[args]"
  * </pre>
  * 
- * </p>
  * <p>
  * Java and Keberos sometimes don't get along together. Here are some things to try:
  * 

--- a/java/src/main/java/org/eyrie/remctl/client/RemctlConnectionPool.java
+++ b/java/src/main/java/org/eyrie/remctl/client/RemctlConnectionPool.java
@@ -22,7 +22,6 @@ public class RemctlConnectionPool extends GenericObjectPool {
     /**
      * Creates a RemctlConnection pool with some intelligent defaults settings.
      * 
-     * <p>
      * <ul>
      * <li>maxWait: 10 seconds</li>
      * <li>minEvictableIdleTimeMillis: 10 minutes</li>

--- a/java/src/main/java/org/eyrie/remctl/core/RemctlException.java
+++ b/java/src/main/java/org/eyrie/remctl/core/RemctlException.java
@@ -28,6 +28,11 @@ public class RemctlException extends RuntimeException {
 
     /**
      * {@link RuntimeException#RuntimeException(String, Throwable)}.
+     *
+     * @param msg
+     *            The detail message
+     * @param t
+     *            The root cause
      */
     public RemctlException(final String msg, final Throwable t) {
         super(msg, t);

--- a/java/src/main/java/org/eyrie/remctl/core/RemctlMessageToken.java
+++ b/java/src/main/java/org/eyrie/remctl/core/RemctlMessageToken.java
@@ -78,7 +78,7 @@ public abstract class RemctlMessageToken implements RemctlToken {
     /**
      * Writes the type-specific data to <code>DataOutputStream</code>. This method is designed to be overridden by child
      * classes of <code>RemctlMessageToken</code> so that child classes don't have to implement the rest of
-     * {@link #write(OutputStream)}.
+     * {@link #write()}.
      * 
      * @param stream
      *            Output stream to which to write the token data


### PR DESCRIPTION
1. Fix the warnings from pom.xml where versions were missing for the
following plugins:
   - maven-source-plugin
   - maven-compiler-plugin
   - maven-surefire-plugin
2. Fix javadoc errors that were failing the build.