### PR TITLE
xstrdup rule->program

### DIFF
--- a/server/commands.c
+++ b/server/commands.c
@@ -217,7 +217,7 @@ create_argv_command(struct rule *rule, struct process *process,
         req_argv[1] = xstrdup("-u");
         req_argv[2] = xstrdup(rule->sudo_user);
         req_argv[3] = xstrdup("--");
-        req_argv[4] = rule->program;
+        req_argv[4] = xstrdup(rule->program);
         j = 5;
     } else {
         program = strrchr(rule->program, '/');


### PR DESCRIPTION
remctl-shell frees the string storing the path to the program to run twice when a rule configuration asks for the program to be run with sudo. This might cause remctl-shell to crash, returning a non-zero exit code to a remote caller even if the command runs successfully.