### PR TITLE
Fix CFLAGS handling for php

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -703,7 +703,7 @@ php/modules/remctl.so: php/config.m4 php/php_remctl.h \
 	fi
 	cd php && $(PHPIZE) --clean && $(PHPIZE)
 	cd php && ./configure CC='$(CC)' CPPFLAGS='$(CPPFLAGS)' \
-	    CFLAGS='$(AM_CFLAGS)' LDFLAGS='$(LDFLAGS)'
+	    CFLAGS='$(CFLAGS)' LDFLAGS='$(LDFLAGS)'
 	cd php && $(MAKE) CFLAGS='$(CFLAGS) $(PHP_WARNINGS)'
 
 # PHP's build system uses INSTALL_ROOT where everyone else uses DESTDIR.


### PR DESCRIPTION
9b8536991719cab3b8636f3b7c924d5bbe37d28a changed the php compilation to use `AM_CFLAGS` instead of `CFLAGS`. On Fedora this meant that the `CFLAGS` option to php's `./configure` was empty, leading to a build failure.

Switch back to `CFLAGS` so we pass our main `CFLAGS` through to the PHP build.