### PR TITLE
Use minitest for Ruby tests

### DIFF
--- a/ruby/test_remctl.rb.in
+++ b/ruby/test_remctl.rb.in
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'fileutils'
-require 'test/unit'
+require 'minitest'
 require 'remctl'
 
 module Helpers
@@ -89,7 +89,7 @@ module Helpers
   end
 end
 
-class TC_RemctlSimple < Test::Unit::TestCase
+class TC_RemctlSimple < Minitest::Test
   include Helpers
 
   def test_simple_success
@@ -157,7 +157,7 @@ class TC_RemctlSimple < Test::Unit::TestCase
   end
 end
 
-class TC_RemctlFull < Test::Unit::TestCase
+class TC_RemctlFull < Minitest::Test
   include Helpers
 
   def test_full_success


### PR DESCRIPTION
Ruby 1.9+ uses Minitest as the backend for Test::Unit. This shim has lost some backwards compatibility over time and it no longer works on Fedora 35. Update the test suite to use minitest directly.