### PR TITLE
perl: fix failing test case

### DIFF
--- a/perl/t/backend/options.t
+++ b/perl/t/backend/options.t
@@ -95,6 +95,6 @@ is($status, 255, 'unknown option returns 255');
 is($output, q{}, '...with no output');
 is(
     $error,
-    qq{number: value "foo" invalid for option number (number expected)\n},
+    qq{number: value "foo" invalid for option number (integer number expected)\n},
     '...and correct error',
 );


### PR DESCRIPTION
The expected value differs from actual remctl error output, causing the test case to fail. This snowballs into RPM build errors during the %check stage.